### PR TITLE
allow 'Allow machine to sleep' to work if 'Allow screen saver to star…

### DIFF
--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1255,7 +1255,7 @@ int main(int argc, char *argv[]) {
     // Better to handle this at the event level, see kbdptr.c
     //CGEnableEventStateCombining(FALSE);
 
-    if (rfbDisableScreenSaver) {
+    if (rfbDisableScreenSaver || rfbNoSleep) {
         /* setup screen saver disabling timer */
         screensaverTimerUPP = NewEventLoopTimerUPP(rfbScreensaverTimer);
         InstallEventLoopTimer(GetMainEventLoop(),

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1047,7 +1047,7 @@ void rfbShutdown(void) {
     [[NSNotificationCenter defaultCenter] removeObserver:vncServerObject];
     [[NSDistributedNotificationCenter defaultCenter] removeObserver:vncServerObject];
 
-    if (rfbDisableScreenSaver) {
+    if (rfbDisableScreenSaver || rfbNoSleep) {
         /* remove the screensaver timer */
         RemoveEventLoopTimer(screensaverTimer);
         DisposeEventLoopTimerUPP(screensaverTimerUPP);


### PR DESCRIPTION
…t' is not checked


OK something weird is going on, where if "Allow screen saver to start" is checked then "Allow machine to sleep" checkbox has no effect.

But the weirder part is that rfbDisableScreenSaver seems to actually "have no effect" at all, by itself.  It's very odd.  With this commit the "Allow machine to sleep" checkbox always does something, at least...