### PR TITLE
fixed instructions for building from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You will find the distributable at /tmp/VineServer.dmg
 
 Run this command from the command line:
 
-    xcodebuild --configuration Deployment
+    xcodebuild -configuration Deployment
 
 Again you will find the distributable at /tmp/VineServer.dmg
 


### PR DESCRIPTION
There is a typo in your instructions for command line builds. The following command does not execute for Xcode 10 (currently the latest version):

```
xcodebuild --configuration Deployment
```

I had to use one dash to make the build process start:

```
xcodebuild -configuration Deployment
```