### PR TITLE
fixed includes in vncauth.c

### DIFF
--- a/OSXvnc-server/vncauth.c
+++ b/OSXvnc-server/vncauth.c
@@ -26,9 +26,9 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <vncauth.h>
-#include <d3des.h>
 #include <time.h>
+#include "vncauth.h"
+#include "d3des.h"
 
 
 


### PR DESCRIPTION
As we've discussed in issue #27 I've fixed an issue with two include directives in `vncauth.c`. Xcode complained about this. I had to change these includes in order to avoid compilation errors.

According to [your comment](https://github.com/pinhead84/OSXvnc/commit/4f611d30ee7e95048accc1115da93068e01b791b#r30681438) I've also changed the order of the directives.