### PR TITLE
Fix memory access crash

### DIFF
--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -108,10 +108,9 @@ void rfbSendClientList() {
     }
 
     [[NSDistributedNotificationCenter defaultCenter] postNotificationName:@"VNCConnections"
-                                                                    object:[NSString stringWithFormat:@"OSXvnc%d",rfbPort]
-                                                                  userInfo:@{@"clientList": clientList}];
+                                                                   object:[NSString stringWithFormat:@"OSXvnc%d",rfbPort]
+                                                                 userInfo:@{@"clientList": clientList}];
 
-    [clientList dealloc];
     [pool release];
 
     pthread_mutex_unlock(&rfbClientListMutex);


### PR DESCRIPTION
In general `dealloc` should never be called explicitly. 