### PR TITLE
Leaked images

### DIFF
--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -656,6 +656,7 @@ void rfbGetFramebufferUpdateInRect(int x, int y, int w, int h) {
             CGContextDrawImage(context, CGRectMake(0, 0, w, h), image);
             imageRef = CGBitmapContextCreateImage(context);
             CGContextRelease(context);
+            CGImageRelease(image);
         } else {
             imageRef = CGDisplayCreateImageForRect(displayID, rect);
         }
@@ -733,6 +734,7 @@ static bool rfbScreenInit(void) {
             CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
             imageRef = CGBitmapContextCreateImage(context);
             CGContextRelease(context);
+            CGImageRelease(image);
         } else {
             imageRef = CGDisplayCreateImage(displayID);
         }

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -654,9 +654,10 @@ void rfbGetFramebufferUpdateInRect(int x, int y, int w, int h) {
                 return;
             }
             CGContextDrawImage(context, CGRectMake(0, 0, w, h), image);
+            CGImageRelease(image);
             imageRef = CGBitmapContextCreateImage(context);
             CGContextRelease(context);
-            CGImageRelease(image);
+            
         } else {
             imageRef = CGDisplayCreateImageForRect(displayID, rect);
         }
@@ -732,9 +733,10 @@ static bool rfbScreenInit(void) {
                 return nil;
             }
             CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
+            CGImageRelease(image);
             imageRef = CGBitmapContextCreateImage(context);
             CGContextRelease(context);
-            CGImageRelease(image);
+            
         } else {
             imageRef = CGDisplayCreateImage(displayID);
         }


### PR DESCRIPTION
Fixes a problem appearing on Macs with Retina displays. 
May be related to issue #32, as I was getting consistent RAM usage increase by a rate 30-40Mb/sec and this fixes it