### PR TITLE
Use different event source for special keys

### DIFF
--- a/OSXvnc-server/VNCServer.h
+++ b/OSXvnc-server/VNCServer.h
@@ -33,6 +33,7 @@
     // This flag will try to change the modifier key state to the required set for the unicode key that came in
     BOOL pressModsForKeys;
 	CGEventSourceRef vncSourceRef;
+	CGEventSourceRef specialKeysVncSourceRef;
 	CGEventTapLocation vncTapLocation;
 
 	TISInputSourceRef unicodeInputSource;

--- a/OSXvnc-server/VNCServer.m
+++ b/OSXvnc-server/VNCServer.m
@@ -763,10 +763,10 @@ static bool isConsoleSession(void) {
     }
     else {
         CGEventRef event;
-		int specialKeysStartingFrom = 96;
+        int specialKeysStartingFrom = 96;
         if (specialKeysVncSourceRef != NULL && keyCode >= specialKeysStartingFrom){
             event = CGEventCreateKeyboardEvent(specialKeysVncSourceRef, keyCode, down);
-		}else {
+        }else {
             event = CGEventCreateKeyboardEvent(vncSourceRef, keyCode, down);
         }
 

--- a/OSXvnc-server/VNCServer.m
+++ b/OSXvnc-server/VNCServer.m
@@ -375,6 +375,7 @@ static bool isConsoleSession(void) {
             // Doesn't combine with any other sources
             NSLog(@"Using Private Event Source");
             vncSourceRef = CGEventSourceCreate(kCGEventSourceStatePrivate);
+            specialKeysVncSourceRef = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
             break;
         case 1:
             // Combines only with other User Session Events
@@ -761,7 +762,13 @@ static bool isConsoleSession(void) {
         CFRelease(event);
     }
     else {
-        CGEventRef event = CGEventCreateKeyboardEvent(vncSourceRef, keyCode, down);
+        CGEventRef event;
+		int specialKeysStartingFrom = 96;
+        if (specialKeysVncSourceRef != NULL && keyCode >= specialKeysStartingFrom){
+            event = CGEventCreateKeyboardEvent(specialKeysVncSourceRef, keyCode, down);
+		}else {
+            event = CGEventCreateKeyboardEvent(vncSourceRef, keyCode, down);
+        }
 
         // The value of this function escapes me (since you still need to specify the keyCode for it to work
         // CGEventKeyboardSetUnicodeString (event, 1, (const UniChar *) &keySym);


### PR DESCRIPTION
Issue: https://github.com/stweil/OSXvnc/issues/54

Issue was possibly due to the following reasons
- Accessibility shortcuts added since Monterey: https://gist.github.com/lukaskubanek/df1cf3287e30095b7265da639b6b43ae
- The Obj C implementation of CGEventPost, CGEventSourceCreate when used with kCGEventSourceStatePrivate and kCGHIDEventTap

Found the fix by trying out some different combinations Event Source and Event Tap

By making use of `kCGEventSourceStateHIDSystemState` for keys with keyCode > 96, the `m` key works fine after pressing   the these keys: Arrow Keys, Home, End, Insert, Function keys, Page Up/Down